### PR TITLE
Try to provide consistent POSIX-like behaviour on Windows and Unix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- Increase the default read/write timeouts on Unix platforms to 3 seconds.
+- Explicitly set `VMIN` and `VTIME` to 0 on Unix platforms in `Settings::set_raw()`.
+- Mimic Unix behavior on Windows: read will return with available data as soon as possible.
+
 # Version 0.2.4 - 2023-10-6
 - Always open serial ports with the `O_NONBLOCK` flag on Unix.
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -9,3 +9,5 @@ mod windows;
 
 #[cfg(windows)]
 pub use windows::*;
+
+const DEFAULT_TIMEOUT_MS: u32 = 3000;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -111,8 +111,8 @@ impl SerialPort {
 	pub fn from_file(file: std::fs::File) -> Self {
 		Self {
 			file,
-			read_timeout_ms: 100,
-			write_timeout_ms: 100,
+			read_timeout_ms: super::DEFAULT_TIMEOUT_MS,
+			write_timeout_ms: super::DEFAULT_TIMEOUT_MS,
 		}
 	}
 
@@ -333,6 +333,8 @@ impl Settings {
 	pub fn set_raw(&mut self) {
 		unsafe {
 			libc::cfmakeraw(&mut self.termios as *mut _ as *mut libc::termios);
+			self.termios.c_cc[libc::VMIN] = 0;
+			self.termios.c_cc[libc::VTIME] = 0;
 		}
 		self.set_char_size(crate::CharSize::Bits8);
 		self.set_stop_bits(crate::StopBits::One);


### PR DESCRIPTION
This PR tries to make reads on Windows behave like on Unix: read will return with available data as soon as possible instead of trying to fill the entire buffer and then time out if not enough data is available.

Sadly, wine doesn't seem to emulate the time-out behaviour properly. It looks like `u32::MAX` has no special meaning, so read calls block forever instead of returning as soon as possible like they should :(