### PR TITLE
Added feature 'with-serde' that allows (de-)serialization of settings…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# Unreleased
+- [add][minor] Add optional support for `serde` with the `serde` feature.
+
 # Version 0.2.8 - 2023-11-03
 - [change][minor] Set `VMIN` to 1 on Unix platforms to work correctly with `epoll()` on Linux.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,10 @@ windows = []
 # Add #[doc(cfg(...))] annotations to platform specific items for better documentation (requires nightly toolchain).
 doc-cfg = []
 
-serde = ["dep:serde", "dep:serde_repr"]
+serde = ["dep:serde"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
-serde_repr = { version = "0.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.109"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ windows = []
 # Add #[doc(cfg(...))] annotations to platform specific items for better documentation (requires nightly toolchain).
 doc-cfg = []
 
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:serde_repr"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
+serde_repr = { version = "0.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.109"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ windows = []
 # Add #[doc(cfg(...))] annotations to platform specific items for better documentation (requires nightly toolchain).
 doc-cfg = []
 
-with-serde = ["serde/derive"]
+serde = ["dep:serde"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ windows = []
 # Add #[doc(cfg(...))] annotations to platform specific items for better documentation (requires nightly toolchain).
 doc-cfg = []
 
+with-serde = ["serde/derive"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.109"
 cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,10 @@ cfg-if = "1.0.0"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["commapi", "fileapi", "handleapi", "ioapiset", "std", "synchapi", "winbase", "winerror", "winreg"] }
 
+[dev-dependencies]
+assert2 = "0.3.11"
+serde_json = "1.0.108"
+serial2 = { path = ".", features = ["serde"] }
+
 [package.metadata.docs.rs]
 features = ["doc-cfg"]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,7 +19,7 @@ pub const COMMON_BAUD_RATES: &[u32] = &[
 
 /// The number of bits per character for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CharSize {
 	/// Characters of 5 bits.
 	Bits5,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "with-serde")]
+use serde::{Deserialize, Serialize};
+
 /// The settings of a serial port.
 #[derive(Clone)]
 pub struct Settings {
@@ -16,6 +19,7 @@ pub const COMMON_BAUD_RATES: &[u32] = &[
 
 /// The number of bits per character for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 pub enum CharSize {
 	/// Characters of 5 bits.
 	Bits5,
@@ -32,6 +36,7 @@ pub enum CharSize {
 
 /// The number of stop bits per character for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 pub enum StopBits {
 	/// One stop bit.
 	One,
@@ -42,6 +47,7 @@ pub enum StopBits {
 
 /// The type of parity check for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 pub enum Parity {
 	/// Do not add a parity bit and do not check for parity.
 	None,
@@ -61,6 +67,7 @@ pub enum Parity {
 
 /// The type of flow control for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 pub enum FlowControl {
 	/// Do not perform any automatic flow control.
 	None,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -36,7 +36,7 @@ pub enum CharSize {
 
 /// The number of stop bits per character for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum StopBits {
 	/// One stop bit.
 	One,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -47,7 +47,7 @@ pub enum StopBits {
 
 /// The type of parity check for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Parity {
 	/// Do not add a parity bit and do not check for parity.
 	None,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use {
+	serde::{Deserialize, Serialize},
+	serde_repr::{Serialize_repr, Deserialize_repr},
+};
 
 /// The settings of a serial port.
 #[derive(Clone)]
@@ -19,30 +22,30 @@ pub const COMMON_BAUD_RATES: &[u32] = &[
 
 /// The number of bits per character for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize_repr, Deserialize_repr), repr(u8))]
 pub enum CharSize {
 	/// Characters of 5 bits.
-	Bits5,
+	Bits5 = 5,
 
 	/// Characters of 6 bits.
-	Bits6,
+	Bits6 = 6,
 
 	/// Characters of 7 bits.
-	Bits7,
+	Bits7 = 7,
 
 	/// Characters of 8 bits.
-	Bits8,
+	Bits8 = 8,
 }
 
 /// The number of stop bits per character for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize_repr, Deserialize_repr), repr(u8))]
 pub enum StopBits {
 	/// One stop bit.
-	One,
+	One = 1,
 
 	/// Two stop bit.
-	Two,
+	Two = 2,
 }
 
 /// The type of parity check for a serial port.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The settings of a serial port.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -67,7 +67,7 @@ pub enum Parity {
 
 /// The type of flow control for a serial port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum FlowControl {
 	/// Do not perform any automatic flow control.
 	None,

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,69 @@
+use assert2::{assert, let_assert};
+
+#[test]
+fn test_serde_char_size() {
+	assert!(let Ok("5") = serde_json::to_string(&serial2::CharSize::Bits5).as_deref());
+	assert!(let Ok("6") = serde_json::to_string(&serial2::CharSize::Bits6).as_deref());
+	assert!(let Ok("7") = serde_json::to_string(&serial2::CharSize::Bits7).as_deref());
+	assert!(let Ok("8") = serde_json::to_string(&serial2::CharSize::Bits8).as_deref());
+
+	assert!(let Ok(serial2::CharSize::Bits5) = serde_json::from_str::<serial2::CharSize>("5"));
+	assert!(let Ok(serial2::CharSize::Bits6) = serde_json::from_str::<serial2::CharSize>("6"));
+	assert!(let Ok(serial2::CharSize::Bits7) = serde_json::from_str::<serial2::CharSize>("7"));
+	assert!(let Ok(serial2::CharSize::Bits8) = serde_json::from_str::<serial2::CharSize>("8"));
+
+	let_assert!(Err(e) = serde_json::from_str::<serial2::CharSize>("4"));
+	assert!(e.to_string() == "invalid value: integer `4`, expected the number 5, 6, 7 or 8 at line 1 column 1");
+
+	let_assert!(Err(e) = serde_json::from_str::<serial2::CharSize>("9"));
+	assert!(e.to_string() == "invalid value: integer `9`, expected the number 5, 6, 7 or 8 at line 1 column 1");
+
+	let_assert!(Err(e) = serde_json::from_str::<serial2::CharSize>("\"5\""));
+	assert!(e.to_string() == "invalid type: string \"5\", expected the number 5, 6, 7 or 8 at line 1 column 3");
+}
+
+#[test]
+fn test_serde_stop_bits() {
+	assert!(let Ok("1") = serde_json::to_string(&serial2::StopBits::One).as_deref());
+	assert!(let Ok("2") = serde_json::to_string(&serial2::StopBits::Two).as_deref());
+
+	assert!(let Ok(serial2::StopBits::One) = serde_json::from_str::<serial2::StopBits>("1"));
+	assert!(let Ok(serial2::StopBits::Two) = serde_json::from_str::<serial2::StopBits>("2"));
+
+	let_assert!(Err(e) = serde_json::from_str::<serial2::StopBits>("0"));
+	assert!(e.to_string() == "invalid value: integer `0`, expected the number 1 or 2 at line 1 column 1");
+
+	let_assert!(Err(e) = serde_json::from_str::<serial2::StopBits>("3"));
+	assert!(e.to_string() == "invalid value: integer `3`, expected the number 1 or 2 at line 1 column 1");
+
+	let_assert!(Err(e) = serde_json::from_str::<serial2::StopBits>("\"1\""));
+	assert!(e.to_string() == "invalid type: string \"1\", expected the number 1 or 2 at line 1 column 3");
+}
+
+#[test]
+fn test_serde_parity() {
+	assert!(let Ok("\"none\"") = serde_json::to_string(&serial2::Parity::None).as_deref());
+	assert!(let Ok("\"even\"") = serde_json::to_string(&serial2::Parity::Even).as_deref());
+	assert!(let Ok("\"odd\"") = serde_json::to_string(&serial2::Parity::Odd).as_deref());
+
+	assert!(let Ok(serial2::Parity::None) = serde_json::from_str::<serial2::Parity>("\"none\""));
+	assert!(let Ok(serial2::Parity::Even) = serde_json::from_str::<serial2::Parity>("\"even\""));
+	assert!(let Ok(serial2::Parity::Odd) = serde_json::from_str::<serial2::Parity>("\"odd\""));
+
+	let_assert!(Err(e) = serde_json::from_str::<serial2::Parity>("\"even-then-odd\""));
+	assert!(e.to_string() == "invalid value: string \"even-then-odd\", expected the string \"none\", \"even\" or \"odd\" at line 1 column 15");
+}
+
+#[test]
+fn test_serde_flow_control() {
+	assert!(let Ok("\"none\"") = serde_json::to_string(&serial2::FlowControl::None).as_deref());
+	assert!(let Ok("\"xon/xoff\"") = serde_json::to_string(&serial2::FlowControl::XonXoff).as_deref());
+	assert!(let Ok("\"rts/cts\"") = serde_json::to_string(&serial2::FlowControl::RtsCts).as_deref());
+
+	assert!(let Ok(serial2::FlowControl::None) = serde_json::from_str::<serial2::FlowControl>("\"none\""));
+	assert!(let Ok(serial2::FlowControl::XonXoff) = serde_json::from_str::<serial2::FlowControl>("\"xon/xoff\""));
+	assert!(let Ok(serial2::FlowControl::RtsCts) = serde_json::from_str::<serial2::FlowControl>("\"rts/cts\""));
+
+	let_assert!(Err(e) = serde_json::from_str::<serial2::FlowControl>("\"plug-in/plug-out\""));
+	assert!(e.to_string() == "invalid value: string \"plug-in/plug-out\", expected the string \"none\", \"xon/xoff\" or \"rts/cts\" at line 1 column 18");
+}


### PR DESCRIPTION
Hello!

I am using this library like:

```rust
use serial2::{SerialPort, CharSize, Parity, StopBits, FlowControl};

#[derive(Debug, Serialize, Deserialize)]
pub struct Settings {
    baudrate: u32,
    char_size: CharSize,
    parity: Parity,
    stop_bits: StopBits,
    flow_control: FlowControl,
}

impl Default for Settings {
    fn default() -> Self {
        Self {
            baudrate: 115200,
            char_size: CharSize::Bits8,
            parity: Parity::None,
            stop_bits: StopBits::One,
            flow_control: FlowControl::None,
        }
    }
}

#[derive(Debug, Default, Serialize, Deserialize)]
pub struct SerialInterface {
    pub serial_config: Settings,
    pub serial_input: Vec<u8>,
    pub serial_output: Vec<u8>,
}
```
I need de-/serialization functionality on the `Settings`. This is why I added a feature "with-serde" to your library.
In Cargo.toml: `serial2 = { version = "0.2.8", features = ["with-serde"] }`

Maybe you find it useful and want to merge it. Feel free to implement differently.