### PR TITLE
Improve documentation about timeouts and composed operations.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# Unreleased
+- [change][patch] Improve documentation about timeouts and composed operations like `read_exact()` and `write_all()`.
+
 # Version 0.2.20 - 2024-03-04
 - [fix][minor] Fix write timeout for Unix platforms.
 

--- a/src/serial_port.rs
+++ b/src/serial_port.rs
@@ -246,26 +246,36 @@ impl SerialPort {
 
 	/// Set the read timeout for the serial port.
 	///
-	/// The timeout set by this function is an upper bound on individual calls to [`std::io::Read::read()`].
+	/// The timeout set by this function is an upper bound on individual calls to [`read()`][Self::read].
 	/// Other platform specific time-outs may trigger before this timeout does.
+	/// Additionally, some functions (like [`Self::read_exact`]) perform multiple calls to `read()`.
 	pub fn set_read_timeout(&mut self, timeout: Duration) -> std::io::Result<()> {
 		self.inner.set_read_timeout(timeout)
 	}
 
 	/// Get the read timeout of the serial port.
+	///
+	/// The timeout set by this function is an upper bound on individual calls to [`read()`][Self::read].
+	/// Other platform specific time-outs may trigger before this timeout does.
+	/// Additionally, some functions (like [`Self::read_exact`]) perform multiple calls to `read()`.
 	pub fn get_read_timeout(&self) -> std::io::Result<Duration> {
 		self.inner.get_read_timeout()
 	}
 
 	/// Set the write timeout for the serial port.
 	///
-	/// The timeout set by this function is an upper bound on individual calls to [`std::io::Write::write()`].
+	/// The timeout set by this function is an upper bound on individual calls to [`write()`][Self::write].
 	/// Other platform specific time-outs may trigger before this timeout does.
+	/// Additionally, some functions (like [`Self::write_all`]) perform multiple calls to `write()`.
 	pub fn set_write_timeout(&mut self, timeout: Duration) -> std::io::Result<()> {
 		self.inner.set_write_timeout(timeout)
 	}
 
 	/// Get the write timeout of the serial port.
+	///
+	/// The timeout set by this function is an upper bound on individual calls to [`write()`][Self::write].
+	/// Other platform specific time-outs may trigger before this timeout does.
+	/// Additionally, some functions (like [`Self::write_all`]) perform multiple calls to `write()`.
 	pub fn get_write_timeout(&self) -> std::io::Result<Duration> {
 		self.inner.get_write_timeout()
 	}


### PR DESCRIPTION
This PR improves the documentation of the timeout functions to mention that composed operations like `read_exact` and `write_all` perform multiple calls to `read()` and `write()`.

Solves #31.