### PR TITLE
Allow 2.5% deviation in baudrate when applying settings on Unix.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 # Unreleased
+- [fix][minor] Allow for a 2.5% deviation in actual baud rate when applying settings on Unix.
 - [add][minor] Implement `Debug` for `SerialPort` showing the underlying file descriptor (Unix) or handle (Windows).
 
 # Version 0.2.26 - 2024-06-21

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# Unreleased
+- [add][minor] Implement `Debug` for `SerialPort` showing the underlying file descriptor (Unix) or handle (Windows).
+
 # Version 0.2.26 - 2024-06-21
 - [add][minor] Support more custom baud rates on iOS and macOS.
 

--- a/src/serial_port.rs
+++ b/src/serial_port.rs
@@ -451,6 +451,12 @@ impl SerialPort {
 	}
 }
 
+impl std::fmt::Debug for SerialPort {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		std::fmt::Debug::fmt(&self.inner, f)
+	}
+}
+
 impl std::io::Read for SerialPort {
 	fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
 		SerialPort::read(self, buf)

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -11,6 +11,14 @@ pub struct SerialPort {
 	pub write_timeout_ms: u32,
 }
 
+impl std::fmt::Debug for SerialPort {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("SerialPort")
+			.field("fd", &self.file.as_raw_fd())
+			.finish()
+	}
+}
+
 cfg_if! {
 	if #[cfg(any(
 		target_os = "ios",

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -12,6 +12,14 @@ pub struct SerialPort {
 	pub file: std::fs::File,
 }
 
+impl std::fmt::Debug for SerialPort {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("SerialPort")
+			.field("handle", &self.file.as_raw_handle())
+			.finish()
+	}
+}
+
 #[derive(Clone)]
 pub struct Settings {
 	pub dcb: winbase::DCB,


### PR DESCRIPTION
Should fix #41 