### PR TITLE
add break support for Unix and Windows

### DIFF
--- a/src/serial_port.rs
+++ b/src/serial_port.rs
@@ -405,6 +405,13 @@ impl SerialPort {
 		self.inner.read_cd()
 	}
 
+	/// Set break state of the serial port.
+	///
+	/// This will hold the serial port in a logical low state when state is true.
+	pub fn set_break(&self, state: bool) -> std::io::Result<()> {
+		self.inner.set_break(state)
+	}
+
 	/// Get the RS-4xx mode of the serial port transceiver.
 	///
 	/// This is currently only supported on Linux.

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -327,6 +327,17 @@ impl SerialPort {
 	pub fn read_cd(&self) -> std::io::Result<bool> {
 		read_pin(&self.file, libc::TIOCM_CD)
 	}
+
+	pub fn set_break(&self, state: bool) -> std::io::Result<()> {
+		unsafe {
+			if state {
+				check(libc::ioctl(self.file.as_raw_fd(), libc::TIOCSBRK as _))?;
+			} else {
+				check(libc::ioctl(self.file.as_raw_fd(), libc::TIOCCBRK as _))?;
+			}
+			Ok(())
+		}
+	}
 }
 
 /// Wait for a file to be readable or writable.

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -289,6 +289,14 @@ impl SerialPort {
 		// I think.
 		read_pin(&self.file, winbase::MS_RLSD_ON)
 	}
+
+	pub fn set_break(&self, state: bool) -> std::io::Result<()> {
+		if state {
+			commapi::SetCommBreak(&self.file)
+		} else {
+			commapi::ClearCommBreak(&self.file)
+		}
+	}
 }
 
 struct Event {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -291,10 +291,12 @@ impl SerialPort {
 	}
 
 	pub fn set_break(&self, state: bool) -> std::io::Result<()> {
-		if state {
-			commapi::SetCommBreak(&self.file)
-		} else {
-			commapi::ClearCommBreak(&self.file)
+		unsafe {
+			if state {
+				check_bool(commapi::SetCommBreak(self.file.as_raw_handle()))
+			} else {
+				check_bool(commapi::ClearCommBreak(self.file.as_raw_handle()))
+			}
 		}
 	}
 }


### PR DESCRIPTION
Self explanatory. I have not tested on Windows but it is working on my Linux machine. This is a bit awkward to implement since the serial is unusable while it is in a "break" state. I chose a simple solution of just having a set state call which can be called on a shared reference. Perhaps a better implementation would be to consume a SerialPort into a BrokenSerialPort and disallow usual operations. One can then convert it back into a SerialPort; I just see a lot of overhead with this and other functionalities might want to make use of the same structure.

Maybe in the future this can be adapted into a different API. There is also no way of using system calls that allow you to schedule a break for x seconds or x byte periods with this. 