### PR TITLE
Fix libc flags in `SerialPort::discard_buffers`

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -293,11 +293,12 @@ impl SerialPort {
 	pub fn discard_buffers(&self, discard_input: bool, discard_output: bool) -> std::io::Result<()> {
 		unsafe {
 			let mut flags = 0;
-			if discard_input {
-				flags |= libc::TCIFLUSH;
-			}
-			if discard_output {
-				flags |= libc::TCOFLUSH;
+			if discard_input && discard_output {
+				flags = libc::TCIOFLUSH;
+			} else if discard_input {
+				flags = libc::TCIFLUSH;
+			} else if discard_output {
+				flags = libc::TCOFLUSH;
 			}
 			check(libc::tcflush(self.file.as_raw_fd(), flags))?;
 			Ok(())


### PR DESCRIPTION
I've noticed that the `SerialPort::discard_buffers` function doesn't work correctly on Linux systems. Due to the [definition](https://github.com/rust-lang/libc/blob/cf82fdf3f22ccfa98ba120efc50d5f39ab2d52ff/src/unix/linux_like/mod.rs#L1132-L1134) of the `TCIFLUSH` and `TCOFLUSH` flags, they can't be combined using a bitwise operation. This PR fixes the issue by using the `TCIOFLUSH` flag instead, which works on all platforms.