### PR TITLE
Fix `Settings::get_baud_rate` on Linux & Android

### DIFF
--- a/src/sys/unix/linux/mod.rs
+++ b/src/sys/unix/linux/mod.rs
@@ -1,4 +1,3 @@
-use cfg_if::cfg_if;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "rs4xx")]
@@ -6,76 +5,6 @@ mod rs4xx;
 
 #[cfg(feature = "rs4xx")]
 pub use rs4xx::*;
-
-cfg_if! {
-	if #[cfg(any(target_arch = "sparc", target_arch = "sparc64"))] {
-		pub const BAUD_RATES: &[(u32, u32)] = &[
-			(libc::B50, 50),
-			(libc::B75, 75),
-			(libc::B110, 110),
-			(libc::B134, 134),
-			(libc::B150, 150),
-			(libc::B200, 200),
-			(libc::B300, 300),
-			(libc::B600, 600),
-			(libc::B1200, 1200),
-			(libc::B1800, 1800),
-			(libc::B2400, 2400),
-			(libc::B4800, 4800),
-			(libc::B9600, 9600),
-			(libc::B19200, 19200),
-			(libc::B38400, 38400),
-			(libc::B57600, 57600),
-			(libc::B76800, 76800),
-			(libc::B115200, 115200),
-			(libc::B153600, 153600),
-			(libc::B230400, 230400),
-			(libc::B307200, 307200),
-			(libc::B460800, 460800),
-			(libc::B500000, 500000),
-			(libc::B576000, 576000),
-			(libc::B614400, 614400),
-			(libc::B921600, 921600),
-			(libc::B1000000, 1000000),
-			(libc::B1152000, 1152000),
-			(libc::B1500000, 1500000),
-			(libc::B2000000, 2000000),
-		];
-	} else {
-		pub const BAUD_RATES: &[(u32, u32)] = &[
-			(libc::B50, 50),
-			(libc::B75, 75),
-			(libc::B110, 110),
-			(libc::B134, 134),
-			(libc::B150, 150),
-			(libc::B200, 200),
-			(libc::B300, 300),
-			(libc::B600, 600),
-			(libc::B1200, 1200),
-			(libc::B1800, 1800),
-			(libc::B2400, 2400),
-			(libc::B4800, 4800),
-			(libc::B9600, 9600),
-			(libc::B19200, 19200),
-			(libc::B38400, 38400),
-			(libc::B57600, 57600),
-			(libc::B115200, 115200),
-			(libc::B230400, 230400),
-			(libc::B460800, 460800),
-			(libc::B500000, 500000),
-			(libc::B576000, 576000),
-			(libc::B921600, 921600),
-			(libc::B1000000, 1000000),
-			(libc::B1152000, 1152000),
-			(libc::B1500000, 1500000),
-			(libc::B2000000, 2000000),
-			(libc::B2500000, 2500000),
-			(libc::B3000000, 3000000),
-			(libc::B3500000, 3500000),
-			(libc::B4000000, 4000000),
-		];
-	}
-}
 
 pub fn enumerate() -> std::io::Result<Vec<PathBuf>> {
 	use std::os::unix::ffi::OsStrExt;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -527,15 +527,13 @@ impl Settings {
 					baud_rate.try_into()
 						.map_err(|_| std::io::Error::other(format!("baud rate out of range: {} > {}", baud_rate, u32::MAX)))
 				}
+			} else if #[cfg(all(
+				any(target_os = "android", target_os = "linux"),
+				not(any(target_arch = "powerpc", target_arch = "powerpc64"))
+			))]
+			{
+				Ok(self.termios.c_ospeed)
 			} else {
-				#[cfg(all(
-					any(target_os = "android", target_os = "linux"),
-					not(any(target_arch = "powerpc", target_arch = "powerpc64"))
-				))]
-				if self.termios.c_cflag & libc::CBAUD == libc::BOTHER {
-					return Ok(self.termios.c_ospeed);
-				}
-
 				unsafe {
 					let termios_speed = libc::cfgetospeed(&self.termios as *const _ as *const _ );
 					let &(_, bits_per_second) = BAUD_RATES.iter()


### PR DESCRIPTION
The `cfgetospeed` function is not supposed to be called with a Termios2 struct. This leads to undefined behavior, depending on the libc implementation. The issue probably got triggered by a recent commit to glibc ([5cf101a](https://sourceware.org/git/?p=glibc.git;a=commit;h=5cf101a85aae0d703cdd8ed7b25fe288e41fdacb)).

As the Termios2 API used on Linux & Android always sets the `c_ospeed` field to the exact baud rate, no matter if the baud rate is one of the predefined values, just use the `c_ospeed` value directly. This behavior of the Termios2 API is also described [here](https://github.com/npat-efault/picocom/blob/master/termios2.txt) and can be seen in the [`tty_termios_encode_baud_rate`](https://elixir.bootlin.com/linux/v2.6.37/source/drivers/tty/tty_ioctl.c) kernel implementation.

Consequently, the predefined baud rates for Linux can also be removed.

Tested on Arch Linux with kernel v6.16.0 and Ubuntu 20.04.4 LTS with kernel v5.15.0.

Fixes #52