### PR TITLE
Include tty0tty null modem emulator devices in SerialPort::available_ports()

### DIFF
--- a/src/sys/unix/linux/mod.rs
+++ b/src/sys/unix/linux/mod.rs
@@ -67,6 +67,12 @@ pub fn enumerate() -> std::io::Result<Vec<PathBuf>> {
 			},
 		}
 
+		// always allow tty0tty (null modem emulator) devices
+		if name.as_bytes().starts_with(b"tnt") {
+			entries.push(dev_path);
+			continue;
+		}
+
 		match name.as_bytes().strip_prefix(b"tty") {
 			// Skip entries called "tty";
 			Some(b"") => continue,


### PR DESCRIPTION
[tty0tty](https://github.com/freemed/tty0tty) is a Linux kernel module that creates the following 8 interconnected tty devices in `/dev`:
```
/dev/tnt0 <=> /dev/tnt1
/dev/tnt2 <=> /dev/tnt3
/dev/tnt4 <=> /dev/tnt5
/dev/tnt6 <=> /dev/tnt7
```