### PR TITLE
Update BAUD_RATES type to (libc::speed_t, u32)

### DIFF
--- a/src/sys/unix/linux/mod.rs
+++ b/src/sys/unix/linux/mod.rs
@@ -7,7 +7,7 @@ mod rs4xx;
 pub use rs4xx::*;
 
 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
-pub const BAUD_RATES: &[(u32, u32)] = &[
+pub const BAUD_RATES: &[(libc::speed_t, u32)] = &[
 	(libc::B50, 50),
 	(libc::B75, 75),
 	(libc::B110, 110),

--- a/src/sys/unix/other.rs
+++ b/src/sys/unix/other.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-pub const BAUD_RATES: &[(u32, u32)] = &[
+pub const BAUD_RATES: &[(libc::speed_t, u32)] = &[
 	// POSIX 2017.1: https://pubs.opengroup.org/onlinepubs/9699919799
 	(libc::B50, 50),
 	(libc::B75, 75),

--- a/src/sys/unix/solarish.rs
+++ b/src/sys/unix/solarish.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 // All values taken from:
 // https://github.com/illumos/illumos-gate/blob/252adeb303174e992b64771bf9639e63a4d55418/usr/src/uts/common/sys/termios.h
 
-pub const BAUD_RATES: &[(u32, u32)] = &[
+pub const BAUD_RATES: &[(libc::speed_t, u32)] = &[
 	(libc::B50, 50),
 	(libc::B75, 75),
 	(libc::B110, 110),


### PR DESCRIPTION
This should fix the build on haiku , which defines speed_t = c_uchar instead of u32 for the baud rate.