### PR TITLE
Improve Unix SerialPort::pair creation portability

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -139,7 +139,17 @@ impl SerialPort {
 	pub fn pair() -> std::io::Result<(Self, Self)> {
 		use std::os::unix::io::FromRawFd;
 		unsafe {
-			let pty_a = check(libc::posix_openpt(libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOCTTY))?;
+			cfg_if! {
+				if #[cfg(any(
+					target_os = "openbsd",
+					target_os = "dragonfly",
+				))] {
+					let pty_a = check(libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY))?;
+					check(libc::fcntl(pty_a, libc::F_SETFD, libc::FD_CLOEXEC))?;
+				} else {
+					let pty_a = check(libc::posix_openpt(libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOCTTY))?;
+				}
+			}
 			check(libc::fcntl(pty_a, libc::F_SETFL, libc::O_NONBLOCK))?;
 			let pty_a = std::fs::File::from_raw_fd(pty_a);
 			let pty_a = Self::from_file(pty_a);

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -420,9 +420,12 @@ fn pts_name(master: &SerialPort) -> std::io::Result<std::path::PathBuf> {
 				target_os = "ios",
 				target_os = "macos",
 				target_os = "netbsd",
+				target_os = "openbsd",
+				target_os = "dragonfly",
 				target_os = "illumos",
 				target_os = "solaris",
 				target_os = "aix",
+				target_os = "haiku",
 		))] {
 			static PTSNAME: std::sync::Mutex<()> = std::sync::Mutex::new(());
 			let _lock = PTSNAME.lock();

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -139,7 +139,8 @@ impl SerialPort {
 	pub fn pair() -> std::io::Result<(Self, Self)> {
 		use std::os::unix::io::FromRawFd;
 		unsafe {
-			let pty_a = check(libc::posix_openpt(libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOCTTY | libc::O_NONBLOCK))?;
+			let pty_a = check(libc::posix_openpt(libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOCTTY))?;
+			check(libc::fcntl(pty_a, libc::F_SETFL, libc::O_NONBLOCK))?;
 			let pty_a = std::fs::File::from_raw_fd(pty_a);
 			let pty_a = Self::from_file(pty_a);
 			check(libc::grantpt(pty_a.file.as_raw_fd()))?;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -142,9 +142,9 @@ impl SerialPort {
 			let pty_a = check(libc::posix_openpt(libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOCTTY | libc::O_NONBLOCK))?;
 			let pty_a = std::fs::File::from_raw_fd(pty_a);
 			let pty_a = Self::from_file(pty_a);
-			let pty_b_name = pts_name(&pty_a)?;
-			check(libc::unlockpt(pty_a.file.as_raw_fd()))?;
 			check(libc::grantpt(pty_a.file.as_raw_fd()))?;
+			check(libc::unlockpt(pty_a.file.as_raw_fd()))?;
+			let pty_b_name = pts_name(&pty_a)?;
 			let pty_b = Self::open(&pty_b_name)?;
 			Ok((pty_a, pty_b))
 		}


### PR DESCRIPTION
This PR improves Unix PTY pair creation portability.
- In SerialPort::pair(), the PTY setup sequence is fixed by calling grantpt() before unlockpt(), and only resolving the slave path after the master side has been properly prepared.
- posix_openpt() usage is made more portable by removing O_NONBLOCK from the open call and applying nonblocking mode afterward with fcntl(), which avoids platform-specific failures such as on FreeBSD.
- For OpenBSD and DragonFly, O_CLOEXEC cannot be passed to posix_openpt(), FD_CLOEXEC is set with fcntl() after opening the PTY.
- The set of Unix targets that fall back to ptsname() instead of ptsname_r() is expanded, covering additional platforms that do not support ptsname_r().

Patch is tested on Linux, OpenBSD, NetBSD, FreeBSD, DragonFly, and Haiku.